### PR TITLE
Fix for syncTime return type in case upstream ETISS changes interface

### DIFF
--- a/FileLoggerPlugin/src/FileLogger.cpp
+++ b/FileLoggerPlugin/src/FileLogger.cpp
@@ -139,11 +139,11 @@ etiss_int32 dbg_write(void *handle, etiss_uint64 addr, etiss_uint8 *buffer, etis
     return sys->dbg_write(sys->handle, addr, buffer, length);
 }
 
-void syncTime(void *handle, ETISS_CPU *cpu)
+etiss_int32 syncTime(void *handle, ETISS_CPU *cpu)
 {
     FileLoggerSystem *lsys = ((FileLoggerSystem *)handle);
     ETISS_System *sys = lsys->orig;
-    sys->syncTime(sys->handle, cpu);
+    return sys->syncTime(sys->handle, cpu);
 }
 
 }


### PR DESCRIPTION
Makes this repo compatible with the ETISS feature request https://github.com/tum-ei-eda/etiss/pull/198